### PR TITLE
Add fs-extra as a bundled dependency

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -62,6 +62,10 @@
       "type": "build"
     },
     {
+      "name": "fs-extra",
+      "type": "bundled"
+    },
+    {
       "name": "projen",
       "type": "peer"
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -10,10 +10,11 @@ const project = new JsiiProject({
 
     entrypoint: 'lib/index.js',
     projenDevDependency: true,
+    bundledDeps: ['fs-extra'],
     devDeps: ['@types/fs-extra@^8'], // This will break if it's on 9
     deps: ['projen'],
-    peerDeps: [ 'projen' ],
-    
+    peerDeps: ['projen'],
+
     eslint: false,
     mergify: false,
 });

--- a/package.json
+++ b/package.json
@@ -47,9 +47,12 @@
     "projen": "^0.17.83"
   },
   "dependencies": {
+    "fs-extra": "^10.0.0",
     "projen": "^0.17.83"
   },
-  "bundledDependencies": [],
+  "bundledDependencies": [
+    "fs-extra"
+  ],
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "version": "0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2033,6 +2033,15 @@ fs-access@^1.0.1:
   dependencies:
     null-check "^1.0.0"
 
+fs-extra@*:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
+  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"


### PR DESCRIPTION
fs-extra is referenced in this project but isn't actually in the package.json. I assume this works for most because when yarn is used projen carries fs-extra up with it (it's bundled there).

Noticed this when trying to make some changes to projen and the unit test was failing on creating this project because it was missing fs-extra.